### PR TITLE
Replaced all references to DocumentSymbol.range with DocumentSymbol.selectionRange

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -82,9 +82,9 @@ export function activate(context: vscode.ExtensionContext) {
       addSymbols(flattenedSymbols, results);
 
       return flattenedSymbols.sort((x: vscode.DocumentSymbol, y: vscode.DocumentSymbol) => {
-        const lineDiff = x.range.start.line - y.range.start.line;
+        const lineDiff = x.selectionRange.start.line - y.selectionRange.start.line;
         if(lineDiff === 0) {
-          return x.range.start.character - y.range.start.character;
+          return x.selectionRange.start.character - y.selectionRange.start.character;
         }
         return lineDiff;
       });
@@ -110,13 +110,13 @@ export function activate(context: vscode.ExtensionContext) {
       symbolIndex = -1;
       do {
         symbolIndex++;
-        member = tree[symbolIndex].range.start;
+        member = tree[symbolIndex].selectionRange.start;
       } while (member.line < cursorLine || member.line === cursorLine && member.character <= cursorCharacter);
     } else {
       symbolIndex = tree.length;
       do {
         symbolIndex--;
-        member = tree[symbolIndex].range.start;
+        member = tree[symbolIndex].selectionRange.start;
       } while (member.line > cursorLine || member.line === cursorLine && member.character >= cursorCharacter);
     }
   };
@@ -141,13 +141,13 @@ export function activate(context: vscode.ExtensionContext) {
 
       if (symbol) {
         editor.selection = new vscode.Selection(
-          symbol.range.start.line,
-          symbol.range.start.character,
-          symbol.range.start.line,
-          symbol.range.start.character
+          symbol.selectionRange.start.line,
+          symbol.selectionRange.start.character,
+          symbol.selectionRange.start.line,
+          symbol.selectionRange.start.character
         );
         vscode.commands.executeCommand("revealLine", {
-          lineNumber: symbol.range.start.line
+          lineNumber: symbol.selectionRange.start.line
         });
       }
       vscode.window.setStatusBarMessage("Previous Member", 1000);
@@ -173,9 +173,14 @@ export function activate(context: vscode.ExtensionContext) {
       symbol = tree[symbolIndex];
 
       if (symbol) {
-        editor.selection = new vscode.Selection(symbol.range.start.line, symbol.range.start.character, symbol.range.start.line, symbol.range.start.character);
+        editor.selection = new vscode.Selection(
+          symbol.selectionRange.start.line,
+          symbol.selectionRange.start.character,
+          symbol.selectionRange.start.line,
+          symbol.selectionRange.start.character
+        );
         vscode.commands.executeCommand("revealLine", {
-          lineNumber: symbol.range.start.line
+          lineNumber: symbol.selectionRange.start.line
         });
       }
       vscode.window.setStatusBarMessage("Next Member", 1000);
@@ -183,12 +188,12 @@ export function activate(context: vscode.ExtensionContext) {
   );
 
   context.subscriptions.push(vscode.workspace.onDidChangeConfiguration(e => {
-		if (e.affectsConfiguration('gotoNextPreviousMember.symbolKinds')) {
-			if (vscode.window.activeTextEditor) {
-				reloadConfiguration();
-			}
-		}
-	}));
+    if (e.affectsConfiguration('gotoNextPreviousMember.symbolKinds')) {
+      if (vscode.window.activeTextEditor) {
+        reloadConfiguration();
+      }
+    }
+  }));
 
   context.subscriptions.push(previousMemberCommand, nextMemberCommand, documentChangeListener, activeEditorChangeListener);
 


### PR DESCRIPTION
To fix #5.

From the [Docs](https://code.visualstudio.com/api/references/vscode-api#DocumentSymbol):

> **DocumentSymbol.range**
> *The range enclosing this symbol not including leading/trailing whitespace but everything else, e.g comments and code.*

> **DocumentSymbol.selectionRange**
> *The range that should be selected and reveal when this symbol is being picked, e.g the name of a function. Must be contained by the range.*

So at a glance, the difference is this:
## DocumentSymbol.range
![image](https://user-images.githubusercontent.com/44216702/56669460-150a1800-66a9-11e9-8930-34c935d5b009.png)

## DocumentSymbol.selectionRange
![image](https://user-images.githubusercontent.com/44216702/56669468-176c7200-66a9-11e9-8857-1606458ec33e.png)

