### PR TITLE
Mark extension to be a UI extension

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,5 +69,8 @@
         "tslint": "^5.8.0",
         "typescript": "^2.6.1",
         "vscode": "^1.1.21"
-    }
+    },
+    "extensionKind": [
+        "ui"
+    ]
 }


### PR DESCRIPTION
Hi,
In my company extensions are not allowed to be installed on remote servers, but they can be installed on personal laptops, running VSCode UI. To indicate that this extension doesn't need to be running on remote server, please consider adding this clause. I like your extension and I wish to be able to use it. Thanks!